### PR TITLE
Add type check for Wallet backends

### DIFF
--- a/sparko/sparko.go
+++ b/sparko/sparko.go
@@ -30,6 +30,9 @@ type SparkoWallet struct {
 	paymentStatusListeners []chan rp.PaymentStatus
 }
 
+// Compile time check to ensure that SparkoWallet fully implements rp.Wallet
+var _ rp.Wallet = (*SparkoWallet)(nil)
+
 func Start(params Params) *SparkoWallet {
 	if !strings.HasPrefix(params.Host, "http") {
 		params.Host = "http://" + params.Host

--- a/void/void.go
+++ b/void/void.go
@@ -8,6 +8,9 @@ func Start() VoidWallet {
 	return VoidWallet{}
 }
 
+// Compile time check to ensure that VoidWallet fully implements rp.Wallet
+var _ rp.Wallet = (*VoidWallet)(nil)
+
 func (v VoidWallet) GetInfo() (rp.WalletInfo, error) {
 	return rp.WalletInfo{
 		Balance: 0,


### PR DESCRIPTION
This PR adds a compile time type check to `SparkoWallet` and `VoidWallet` to ensure they fully implement `Wallet`.

This is the same approach LND users for their [gRPC service implementations](https://github.com/lightningnetwork/lnd/blob/485ec0f697d0f6b09eebdcf55b39d175f927ee59/rpcserver.go#L639).

If you don't properly implement `Wallet`, you get an error like the following:
```
> go build github.com/fiatjaf/relampago/sparko
# github.com/fiatjaf/relampago/sparko
sparko/sparko.go:34:5: cannot use (*SparkoWallet)(nil) (type *SparkoWallet) as type relampago.Wallet in assignment:
        *SparkoWallet does not implement relampago.Wallet (missing GetInfo method)
```