### PR TITLE
Configurable lightning backend timeout

### DIFF
--- a/connect/connect.go
+++ b/connect/connect.go
@@ -14,7 +14,7 @@ import (
 
 type LightningBackendSettings struct {
 	BackendType    string `envconfig:"LIGHTNING_BACKEND_TYPE"`
-	ConnectTimeout string `envconfig:"CONNECT_TIMEOUT" default:"15"`
+	ConnectTimeout string `envconfig:"LIGHTNING_CONNECT_TIMEOUT" default:"15"`
 
 	SparkoURL   string `envconfig:"SPARKO_URL"`
 	SparkoToken string `envconfig:"SPARKO_TOKEN"`

--- a/lnd/lnd.go
+++ b/lnd/lnd.go
@@ -22,9 +22,10 @@ import (
 var PaymentPollInterval = 30 * time.Second
 
 type Params struct {
-	Host         string
-	CertPath     string
-	MacaroonPath string
+	Host           string
+	CertPath       string
+	MacaroonPath   string
+	ConnectTimeout time.Duration
 }
 
 type LndWallet struct {
@@ -64,6 +65,7 @@ func Start(params Params) (*LndWallet, error) {
 	}
 	dialOpts = append(dialOpts, grpc.WithPerRPCCredentials(creds))
 	dialOpts = append(dialOpts, grpc.WithBlock())
+	dialOpts = append(dialOpts, grpc.WithTimeout(params.ConnectTimeout))
 
 	// Connect
 	conn, err := grpc.Dial(params.Host, dialOpts...)

--- a/sparko/sparko.go
+++ b/sparko/sparko.go
@@ -16,8 +16,9 @@ import (
 )
 
 type Params struct {
-	Host string
-	Key  string
+	Host           string
+	Key            string
+	ConnectTimeout time.Duration
 
 	InvoiceLabelPrefix string // optional, defaults to 'relampago'
 }
@@ -44,7 +45,7 @@ func Start(params Params) (*SparkoWallet, error) {
 	spark := &lightning.Client{
 		SparkURL:    params.Host + "/rpc",
 		SparkToken:  params.Key,
-		CallTimeout: time.Second * 15,
+		CallTimeout: params.ConnectTimeout,
 	}
 
 	s := &SparkoWallet{


### PR DESCRIPTION
- added an optional timeout param to prevent indefinite hang when attempting to grpc.Dial() an unresponsive lndgrpc endpoint. default value is 15s, to match the hardcoded timeout value set in sparko.Start()
- replaced the hardcoded sparko timeout to also respect this value