### PR TITLE
Fix sparko url preparing

### DIFF
--- a/sparko/sparko.go
+++ b/sparko/sparko.go
@@ -35,9 +35,9 @@ func Start(params Params) (*SparkoWallet, error) {
 	if !strings.HasPrefix(params.Host, "http") {
 		params.Host = "http://" + params.Host
 	}
-	if strings.HasSuffix(params.Host, "/rpc") {
-		params.Host = params.Host[0 : len(params.Host)-4]
-	}
+	
+	params.Host = strings.TrimSuffix(params.Host, "/rpc")
+	params.Host = strings.TrimSuffix(params.Host, "/")
 
 	spark := &lightning.Client{
 		SparkURL:    params.Host + "/rpc",

--- a/sparko/sparko.go
+++ b/sparko/sparko.go
@@ -36,8 +36,8 @@ func Start(params Params) (*SparkoWallet, error) {
 		params.Host = "http://" + params.Host
 	}
 	
-	params.Host = strings.TrimSuffix(params.Host, "/rpc")
 	params.Host = strings.TrimSuffix(params.Host, "/")
+	params.Host = strings.TrimSuffix(params.Host, "/rpc")
 
 	spark := &lightning.Client{
 		SparkURL:    params.Host + "/rpc",


### PR DESCRIPTION
If sparko url will have a slash at the end (`SPARKO_URL=https://spark.example.com/`) - methods will not work, because end of url will looks like `.com//rpc` and logs can't help with that